### PR TITLE
Added try catch for better error reporting

### DIFF
--- a/@rocketseat/gatsby-theme-docs-core/gatsby-node.js
+++ b/@rocketseat/gatsby-theme-docs-core/gatsby-node.js
@@ -130,6 +130,8 @@ exports.createPages = (
     // Generate docs pages
     const docs = result.data.files.edges;
     docs.forEach((doc) => {
+      try: 
+      {
       const {
         childMdx: {
           fields: { slug },
@@ -162,6 +164,10 @@ exports.createPages = (
           repositoryProvider: repositoryEditUrl.provider || '',
         },
       });
+      }
+      catch (e) {
+        reporter.error(`Error creating a doc: ` + e);
+      }
     });
 
     reporter.success(`docs pages created`);


### PR DESCRIPTION
If there's some error in the pages, this was failing badly, with no way to figure out the offending page.
"@rocketseat/gatsby-theme-docs-core" threw an error while running the createPages lifecycle:

Cannot read properties of null (reading 'fields')

<!-- If this is your first time, please read our contribution guidelines: (https://github.com/jpedroschmitz/rocketdocs/blob/main/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
<!--- Describe the change below, including rationale and design decisions -->

<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->

**Additional context**
<!-- Add any other context or screenshots about the feature request here. -->
