### PR TITLE
chore: fix peerDependencies to React 18

### DIFF
--- a/.changeset/famous-rockets-jam.md
+++ b/.changeset/famous-rockets-jam.md
@@ -1,0 +1,5 @@
+---
+'@rocketseat/gatsby-theme-docs': patch
+---
+
+Fix peerDependencies to React 18

--- a/@rocketseat/gatsby-theme-docs/package.json
+++ b/@rocketseat/gatsby-theme-docs/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "gatsby": "^5.0.0",
-    "react": "^16.9.0 || ^17.0.0",
-    "react-dom": "^16.9.0 || ^17.0.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }


### PR DESCRIPTION
<!-- If this is your first time, please read our contribution guidelines: (https://github.com/jpedroschmitz/rocketdocs/blob/main/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
<!--- Describe the change below, including rationale and design decisions -->
Fixes peerDependencies to React 18
<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->

**Additional context**
<!-- Add any other context or screenshots about the feature request here. -->
Couldn't get the new `v4.0.0` package to install in my repo.  This was the error (I use npm):
```
❯ npm i
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: devices.esphome.io@1.0.0
npm ERR! Found: react@18.2.0
npm ERR! node_modules/react
npm ERR!   react@"^18.2.0" from the root project
npm ERR!   peer react@"^18.0.0 || ^0.0.0" from gatsby@5.9.1
npm ERR!   node_modules/gatsby
npm ERR!     gatsby@"^5.9.1" from the root project
npm ERR!     peer gatsby@"^5.0.0" from @rocketseat/gatsby-theme-docs@4.0.0
npm ERR!     node_modules/@rocketseat/gatsby-theme-docs
npm ERR!       @rocketseat/gatsby-theme-docs@"^4.0.0" from the root project
npm ERR!   1 more (react-dom)
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.9.0 || ^17.0.0" from @rocketseat/gatsby-theme-docs@4.0.0
npm ERR! node_modules/@rocketseat/gatsby-theme-docs
npm ERR!   @rocketseat/gatsby-theme-docs@"^4.0.0" from the root project
```